### PR TITLE
Reduce memory allocation for list mergers

### DIFF
--- a/pkg/merger/cp_merge.go
+++ b/pkg/merger/cp_merge.go
@@ -46,8 +46,8 @@ func (cp *cpMerge) Merge(rid Rid, threshold int) ([]MergeCandidate, error) {
 		j, endMergeCandidate = 0, len(candidates)
 
 		for j < endMergeCandidate || isValid {
-			if j >= endMergeCandidate || (isValid && candidates[j].Position > current) {
-				tmp = append(tmp, MergeCandidate{current, 1})
+			if j >= endMergeCandidate || (isValid && candidates[j].Position() > current) {
+				tmp = append(tmp, NewMergeCandidate(current, 1))
 
 				if list.HasNext() {
 					current, err = list.Next()
@@ -58,11 +58,11 @@ func (cp *cpMerge) Merge(rid Rid, threshold int) ([]MergeCandidate, error) {
 				} else {
 					isValid = false
 				}
-			} else if !isValid || (j < endMergeCandidate && candidates[j].Position < current) {
+			} else if !isValid || (j < endMergeCandidate && candidates[j].Position() < current) {
 				tmp = append(tmp, candidates[j])
 				j++
 			} else {
-				candidates[j].Overlap++
+				candidates[j].Increment()
 				tmp = append(tmp, candidates[j])
 				j++
 
@@ -85,19 +85,19 @@ func (cp *cpMerge) Merge(rid Rid, threshold int) ([]MergeCandidate, error) {
 		tmp = tmp[:0]
 
 		for _, c := range candidates {
-			current, err := rid[i].LowerBound(c.Position)
+			current, err := rid[i].LowerBound(c.Position())
 
 			if err != nil && err != ErrIteratorIsNotDereferencable {
 				return nil, err
 			}
 
 			if err != ErrIteratorIsNotDereferencable {
-				if current == c.Position {
-					c.Overlap++
+				if current == c.Position() {
+					c.Increment()
 				}
 			}
 
-			if c.Overlap+(lenRid-i-1) >= threshold {
+			if c.Overlap() +(lenRid-i-1) >= threshold {
 				tmp = append(tmp, c)
 			}
 		}

--- a/pkg/merger/divide_skip.go
+++ b/pkg/merger/divide_skip.go
@@ -47,7 +47,7 @@ func (ds *divideSkip) Merge(rid Rid, threshold int) ([]MergeCandidate, error) {
 	)
 
 	for _, c := range candidates {
-		position = c.Position
+		position = c.Position()
 
 		for _, longList := range lLong {
 			r, err := longList.LowerBound(position)
@@ -57,11 +57,11 @@ func (ds *divideSkip) Merge(rid Rid, threshold int) ([]MergeCandidate, error) {
 			}
 
 			if err == nil && r == position {
-				c.Overlap++
+				c.Increment()
 			}
 		}
 
-		if c.Overlap >= threshold {
+		if c.Overlap() >= threshold {
 			result = append(result, c)
 		}
 	}

--- a/pkg/merger/list_merger.go
+++ b/pkg/merger/list_merger.go
@@ -24,18 +24,22 @@ func (p Rid) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
 // MergeCandidate is result of merging Rid
 type MergeCandidate uint64
 
+// NewMergeCandidate creates a new instance of MergeCandidate
 func NewMergeCandidate(position uint32, overlap int) MergeCandidate {
 	return MergeCandidate(uint64(position) << 32 | uint64(overlap))
 }
 
+// Position returns the given position of the candidate
 func (m MergeCandidate) Position() uint32 {
 	return uint32(m >> 32)
 }
 
+// Overlap returns the current overlap count of the candidate
 func (m MergeCandidate) Overlap() int {
 	return int(uint32(m))
 }
 
+// Increment increments the overlap value of the candidate
 func (m *MergeCandidate) Increment() {
 	*m = NewMergeCandidate(m.Position(), m.Overlap() + 1)
 }

--- a/pkg/merger/list_merger.go
+++ b/pkg/merger/list_merger.go
@@ -22,7 +22,21 @@ func (p Rid) Less(i, j int) bool { return p[i].Len() < p[j].Len() }
 func (p Rid) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
 
 // MergeCandidate is result of merging Rid
-type MergeCandidate struct {
-	Position uint32
-	Overlap  int
+type MergeCandidate uint64
+
+func NewMergeCandidate(position uint32, overlap int) MergeCandidate {
+	return MergeCandidate(uint64(position) << 32 | uint64(overlap))
 }
+
+func (m MergeCandidate) Position() uint32 {
+	return uint32(m >> 32)
+}
+
+func (m MergeCandidate) Overlap() int {
+	return int(uint32(m))
+}
+
+func (m *MergeCandidate) Increment() {
+	*m = NewMergeCandidate(m.Position(), m.Overlap() + 1)
+}
+

--- a/pkg/merger/list_merger_test.go
+++ b/pkg/merger/list_merger_test.go
@@ -29,7 +29,7 @@ func TestMerge(t *testing.T) {
 			}
 
 			for _, candidate := range candidates {
-				actual[candidate.Overlap] = append(actual[candidate.Overlap], candidate.Position)
+				actual[candidate.Overlap()] = append(actual[candidate.Overlap()], candidate.Position())
 			}
 
 			if !reflect.DeepEqual(actual, c.expected) {

--- a/pkg/merger/merge_skip.go
+++ b/pkg/merger/merge_skip.go
@@ -84,10 +84,7 @@ func (ms *mergeSkip) Merge(rid Rid, threshold int) ([]MergeCandidate, error) {
 		n := len(poppedItems)
 
 		if n >= threshold {
-			result = append(result, MergeCandidate{
-				Position: t.position,
-				Overlap:  n,
-			})
+			result = append(result, NewMergeCandidate(t.position, n))
 
 			for _, item := range poppedItems {
 				cur := rid[item.ridID]

--- a/pkg/merger/scan_count.go
+++ b/pkg/merger/scan_count.go
@@ -33,8 +33,8 @@ func (lm *scanCount) Merge(rid Rid, threshold int) ([]MergeCandidate, error) {
 		j, endMergeCandidate = 0, len(candidates)
 
 		for j < endMergeCandidate || isValid {
-			if j >= endMergeCandidate || (isValid && candidates[j].Position > current) {
-				tmp = append(tmp, MergeCandidate{current, 1})
+			if j >= endMergeCandidate || (isValid && candidates[j].Position() > current) {
+				tmp = append(tmp, NewMergeCandidate(current, 1))
 
 				if list.HasNext() {
 					current, err = list.Next()
@@ -45,11 +45,11 @@ func (lm *scanCount) Merge(rid Rid, threshold int) ([]MergeCandidate, error) {
 				} else {
 					isValid = false
 				}
-			} else if !isValid || (j < endMergeCandidate && candidates[j].Position < current) {
+			} else if !isValid || (j < endMergeCandidate && candidates[j].Position() < current) {
 				tmp = append(tmp, candidates[j])
 				j++
 			} else {
-				candidates[j].Overlap++
+				candidates[j].Increment()
 				tmp = append(tmp, candidates[j])
 				j++
 
@@ -71,7 +71,7 @@ func (lm *scanCount) Merge(rid Rid, threshold int) ([]MergeCandidate, error) {
 	tmp = tmp[:0]
 
 	for _, c := range candidates {
-		if c.Overlap >= threshold {
+		if c.Overlap() >= threshold {
 			tmp = append(tmp, c)
 		}
 	}

--- a/pkg/suggest/ngram_index.go
+++ b/pkg/suggest/ngram_index.go
@@ -140,8 +140,8 @@ func (n *nGramIndexImpl) fuzzySearch(
 			}
 
 			for _, c := range candidates {
-				score := 1 - metric.Distance(c.Overlap, sizeA, sizeB)
-				selector.Add(c.Position, score)
+				score := 1 - metric.Distance(c.Overlap(), sizeA, sizeB)
+				selector.Add(c.Position(), score)
 			}
 		}
 	}
@@ -160,7 +160,7 @@ func (n *nGramIndexImpl) autoComplete(query string, selector TopKSelector) ([]Ca
 	}
 
 	for i, c := range candidates {
-		selector.Add(c.Position, float64(-i))
+		selector.Add(c.Position(), float64(-i))
 	}
 
 	return selector.GetCandidates(), nil


### PR DESCRIPTION
This reduces the memory allocation for `ListMerger` algorithms. We declare `MergeCandidate` as `uint64` type and store the `position`  in the first 32 bits and the `overlap` in the least. Here is some benchmarks:

```
benchmark                  old ns/op     new ns/op     delta
BenchmarkWordsOnDisc-8     358533        317211        -11.53%

benchmark                  old allocs     new allocs     delta
BenchmarkWordsOnDisc-8     614            613            -0.16%

benchmark                  old bytes     new bytes     delta
BenchmarkWordsOnDisc-8     112773        65468         -41.95%

```